### PR TITLE
ENH: add new records + explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ Report your hutch's current status and track it over time via the archiver.
 
 PVs:
 
-``IOC:TST:EXPSTATE:State.VAL``: for current state description
+``IOC:$(HUTCH):EXPSTATE:State.VAL``: for current state description
 
-``IOC:TST:EXPSTATE:State.INDX``: to set/get current state index
+``IOC:$(HUTCH):EXPSTATE:State.INDX``: to set/get current state index
 
-``IOC:TST:EXPSTATE:StateOptions``: to set/get all possible states
+``IOC:$(HUTCH):EXPSTATE:StateOptions``: to set/get all possible states
 
-``IOC:TST:EXPSTATE:UserStatus.VAL$``: free-form for user-reported status
+``IOC:$(HUTCH):EXPSTATE:StateOptionsJSON``: JSON format of all possible states
+
+``IOC:$(HUTCH):EXPSTATE:UserStatus``: free-form for user-reported status
+(Access this by way of ``caget -S IOC:$(HUTCH):EXPSTATE:UserStatus``)
+

--- a/app/Db/exp_state.template
+++ b/app/Db/exp_state.template
@@ -1,13 +1,27 @@
+# Experiment State Tracker
+#
+# Record API notes:
+#
+# * The client should update :StateOptions and :StateOptionsJSON
+#   either at startup or when updates are available.
+# * The client should write to :StateOptions.INDX when a new state
+#   change has happened.
+# * The free-form :UserStatus may be updated as needed and has no
+#   real restrictions except its maximum length of $(USER_STATUS_MAX)
+#   which defaults to 1024.
+# * The client may monitor :State (or :StateString) 
+#   and :State.INDX (or :StateIndex) to get status updates.
+
 record(waveform, "$(P):StateOptions") {
     field(DESC, "All possible experiment states")
     # Array of strings (40 chars):
     field(FTVL, "STRING")
     # Maximum amount of strings:
-    field(NELM, $(MAX_STRINGS=200))
+    field(NELM, "$(MAX_STRINGS=200)")
     field(APST, "On Change")
     field(MPST, "On Change")
     field(PINI, "1")
-    info(autosaveFields, "VAL NELM")
+    info(autosaveFields, "VAL NELM DESC")
 }
 
 record(subArray, "$(P):State") {
@@ -21,13 +35,35 @@ record(subArray, "$(P):State") {
     field(NELM, "1")
     # Buffer must be the same size as the input to read in all values
     field(MALM, "$(MAX_STRINGS=200)")
-    info(autosaveFields, "INDX")
+    info(autosaveFields, "INDX DESC")
 }
 
+# Some clients (the archiver appliance included) may have issues with the
+# subArray and waveform of strings above.  Expose the state index and strings
+# as separate records for their convenience:
 record(longin, "$(P):StateIndex") {
     field(DESC, "Current experiment state index")
     field(INP, "$(P):State.INDX CP MS")
-    info(autosaveFields, "VAL")
+    info(autosaveFields, "VAL DESC")
+}
+
+record(stringin, "$(P):StateString") {
+    field(DESC, "Current experiment state string")
+    field(INP, "$(P):State.VAL[0] CP MS")
+    field(APST, "On Change")
+    field(MPST, "On Change")
+    info(autosaveFields, "VAL DESC")
+}
+
+record(lso, "$(P):StateOptionsJSON") {
+    field(DESC, "StateOptions as a JSON dictionary")
+    # Put to $(P):StateOptionsJSON.VAL$ for long-string access.
+    # Maximum length of the string:
+    field(SIZV, "$(OPTIONS_MAX=16384)")
+    field(APST, "On Change")
+    field(MPST, "On Change")
+    field(PINI, "1")
+    info(autosaveFields, "VAL DESC")
 }
 
 record(lso, "$(P):UserStatus") {

--- a/app/Db/exp_state.template
+++ b/app/Db/exp_state.template
@@ -4,9 +4,14 @@
 #
 # * The client should update :StateOptions and :StateOptionsJSON.VAL$
 #   either at startup or when changes to the state options are available.
+#   :StateOptions is a waveform of strings, each of which is a valid
+#   experimental state. :StateOptionsJSON mirrors :StateOptions and reflects
+#   the states in a serialized JSON object representation (which is easily
+#   archived and consumed by Python clients).
 # * Individual state options are limited to DBF_STRING length (40 chars).
 # * The client should write to :StateOptions.INDX when a new state
-#   change has happened.
+#   change is desired. This value refers to the array index of the state
+#   option as in :StateOptions above.
 # * The free-form :UserStatus (long string access by way of :UserStatus.VAL$)
 #   may be updated as needed and has no real restrictions except its maximum
 #   length of $(USER_STATUS_MAX) which defaults to 1024.

--- a/app/Db/exp_state.template
+++ b/app/Db/exp_state.template
@@ -2,7 +2,7 @@
 #
 # Record API notes:
 #
-# * The client should update :StateOptions and :StateOptionsJSON.VAL$
+# * The client should update :StateOptions and :StateOptionsJSON
 #   either at startup or when changes to the state options are available.
 #   :StateOptions is a waveform of strings, each of which is a valid
 #   experimental state. :StateOptionsJSON mirrors :StateOptions and reflects
@@ -12,9 +12,9 @@
 # * The client should write to :StateOptions.INDX when a new state
 #   change is desired. This value refers to the array index of the state
 #   option as in :StateOptions above.
-# * The free-form :UserStatus (long string access by way of :UserStatus.VAL$)
-#   may be updated as needed and has no real restrictions except its maximum
-#   length of $(USER_STATUS_MAX) which defaults to 1024.
+# * The free-form :UserStatus may be updated as needed and has no real
+#   restrictions except its maximum length of the macro USER_STATUS_MAX, which
+#   defaults to 1024.
 # * The client may monitor :State (or :StateString) 
 #   and :State.INDX (or :StateIndex) to get status updates.
 
@@ -61,22 +61,24 @@ record(stringin, "$(P):StateString") {
     info(autosaveFields, "VAL DESC")
 }
 
-record(lso, "$(P):StateOptionsJSON") {
+record(waveform, "$(P):StateOptionsJSON") {
     field(DESC, "StateOptions as a JSON dictionary")
-    # Put to $(P):StateOptionsJSON.VAL$ for long-string access.
+    # Array of char, i.e., a long string:
+    field(FTVL, "CHAR")
     # Maximum length of the string:
-    field(SIZV, "$(OPTIONS_MAX=16384)")
+    field(NELM, "$(OPTIONS_MAX=16384)")
     field(APST, "On Change")
     field(MPST, "On Change")
     field(PINI, "1")
     info(autosaveFields, "VAL DESC")
 }
 
-record(lso, "$(P):UserStatus") {
+record(waveform, "$(P):UserStatus") {
     field(DESC, "Free-form user-specified status")
-    # Put to $(P):UserStatus.VAL$ for long-string access.
+    # Array of char, i.e., a long string:
+    field(FTVL, "CHAR")
     # Maximum length of the string:
-    field(SIZV, "$(USER_STATUS_MAX=1024)")
+    field(NELM, "$(USER_STATUS_MAX=1024)")
     field(APST, "On Change")
     field(MPST, "On Change")
     field(PINI, "1")

--- a/app/Db/exp_state.template
+++ b/app/Db/exp_state.template
@@ -2,13 +2,14 @@
 #
 # Record API notes:
 #
-# * The client should update :StateOptions and :StateOptionsJSON
-#   either at startup or when updates are available.
+# * The client should update :StateOptions and :StateOptionsJSON.VAL$
+#   either at startup or when changes to the state options are available.
+# * Individual state options are limited to DBF_STRING length (40 chars).
 # * The client should write to :StateOptions.INDX when a new state
 #   change has happened.
-# * The free-form :UserStatus may be updated as needed and has no
-#   real restrictions except its maximum length of $(USER_STATUS_MAX)
-#   which defaults to 1024.
+# * The free-form :UserStatus (long string access by way of :UserStatus.VAL$)
+#   may be updated as needed and has no real restrictions except its maximum
+#   length of $(USER_STATUS_MAX) which defaults to 1024.
 # * The client may monitor :State (or :StateString) 
 #   and :State.INDX (or :StateIndex) to get status updates.
 

--- a/app/Db/exp_state.tpl-arch
+++ b/app/Db/exp_state.tpl-arch
@@ -1,4 +1,6 @@
 $(P)StateOptions   100    monitor
+$(P)StateOptionsJSON   100    monitor
 $(P)StateIndex   1    monitor
+$(P)StateString   1    monitor
 $(P)State   1    monitor
 $(P)UserStatus   1    monitor

--- a/app/Db/exp_state.tpl-req
+++ b/app/Db/exp_state.tpl-req
@@ -1,5 +1,13 @@
+$(P)State.DESC
 $(P)State.INDX
 $(P)State.VAL
+$(P)StateIndex.DESC
 $(P)StateIndex.VAL
+$(P)StateString.DESC
+$(P)StateString.VAL
+$(P)StateOptions.DESC
 $(P)StateOptions.VAL
+$(P)StateOptionsJSON.DESC
+$(P)StateOptionsJSON.VAL
+$(P)UserStatus.DESC
 $(P)UserStatus.VAL


### PR DESCRIPTION
* Adds `:StateString`
* Adds `:StateOptionsJSON`
* Currently deployed as ioc-tst-expstate
* Switch from `lso` to `waveform` `FTVL=CHAR` strings
* Update readme / api notes