### PR TITLE
ENH: screen fills the json blob, max 1 hour, add launch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ envPaths
 .DS_Store
 tags
 /RELEASE_SITE
+__pycache__

--- a/launch_screen.sh
+++ b/launch_screen.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export PCDS_CONDA_VER=5.1.1
+source /cds/group/pcds/pyps/conda/pcds_conda
+
+LAUNCHER="$(readlink -f ${BASH_SOURCE[0]})"
+UI="$(dirname ${LAUNCHER})/screen"
+
+pydm --hide-nav-bar --hide-menu-bar --hide-status-bar -m "endstation=${1}" "${UI}/est.py"

--- a/screen/est.py
+++ b/screen/est.py
@@ -120,8 +120,9 @@ class ESTApp(Display):
         )
         state_options.put([state.desc for state in experiment_states.values()])
         state_json = EpicsSignal(
-            f'IOC:{endstation}:EXPSTATE:StateOptionsJSON.VAL$',
+            f'IOC:{endstation}:EXPSTATE:StateOptionsJSON',
             name='state_options_json',
+            string=True,
         )
         state_json.put(
             json.dumps(

--- a/screen/est.ui
+++ b/screen/est.ui
@@ -184,7 +184,7 @@
           <string/>
          </property>
          <property name="channel" stdset="0">
-          <string>ca://IOC:${endstation}:EXPSTATE:UserStatus.VAL$</string>
+          <string>ca://IOC:${endstation}:EXPSTATE:UserStatus</string>
          </property>
          <property name="displayFormat" stdset="0">
           <enum>PyDMLineEdit::String</enum>


### PR DESCRIPTION
- Put to the json string on startup
- Cap the timer to 1 hour (60 minutes)
- Add basic launcher script